### PR TITLE
Fix an error in case of 'type' ctype param

### DIFF
--- a/lamson/encoding.py
+++ b/lamson/encoding.py
@@ -175,8 +175,8 @@ class MIMEPart(MIMEBase):
     thing you'd encode, there's just this one, and it figures out how to
     encode what you ask it.
     """
-    def __init__(self, _type, **params):
-        self.maintype, self.subtype = _type.split('/')
+    def __init__(self, type_, **params):
+        self.maintype, self.subtype = type_.split('/')
         MIMEBase.__init__(self, self.maintype, self.subtype, **params)
 
     def add_text(self, content):

--- a/lamson/encoding.py
+++ b/lamson/encoding.py
@@ -175,8 +175,8 @@ class MIMEPart(MIMEBase):
     thing you'd encode, there's just this one, and it figures out how to
     encode what you ask it.
     """
-    def __init__(self, type, **params):
-        self.maintype, self.subtype = type.split('/')
+    def __init__(self, _type, **params):
+        self.maintype, self.subtype = _type.split('/')
         MIMEBase.__init__(self, self.maintype, self.subtype, **params)
 
     def add_text(self, content):


### PR DESCRIPTION
Using a `type` Content-Type parameter results in:
`EncodingError: Content-Type malformed, not allowed: 'multipart/related'; {'type': 'text/html'} (Python ERROR: __init__() got multiple values for keyword argument 'type'`

This change is consistent with `mail.MIMEBase.__init__` param names.
