### PR TITLE
allows lamson to be run as a normal (nondaemon) process

### DIFF
--- a/lamson/commands.py
+++ b/lamson/commands.py
@@ -39,7 +39,7 @@ import email
 
 def log_command(port=8825, host='127.0.0.1', chroot=False,
                 chdir=".", uid=False, gid=False, umask=False, pid="./run/log.pid",
-               FORCE=False):
+               FORCE=False, debug=False):
     """
     Runs a logging only server on the given hosts and port.  It logs
     each message it receives and also stores it to the run/queue 
@@ -59,7 +59,7 @@ def log_command(port=8825, host='127.0.0.1', chroot=False,
     uid or gid without doing the priv drop operation.
     """
     loader = lambda: utils.make_fake_settings(host, port)
-    utils.start_server(pid, FORCE, chroot, chdir, uid, gid, umask, loader)
+    utils.start_server(pid, FORCE, chroot, chdir, uid, gid, umask, loader, debug)
 
 
 def send_command(port=8825, host='127.0.0.1', username=False, password=False,

--- a/lamson/commands.py
+++ b/lamson/commands.py
@@ -110,7 +110,7 @@ def sendmail_command(port=8825, host='127.0.0.1', debug=0, TRAILING=None):
 
 
 def start_command(pid='./run/smtp.pid', FORCE=False, chroot=False, chdir=".",
-                  boot="config.boot", uid=False, gid=False, umask=False):
+                  boot="config.boot", uid=False, gid=False, umask=False, debug=False):
     """
     Runs a lamson server out of the current directory:
 
@@ -118,7 +118,7 @@ def start_command(pid='./run/smtp.pid', FORCE=False, chroot=False, chdir=".",
             -umask False -uid False -gid False -boot config.boot
     """
     loader = lambda: utils.import_settings(True, from_dir=os.getcwd(), boot_module=boot)
-    utils.start_server(pid, FORCE, chroot, chdir, uid, gid, umask, loader)
+    utils.start_server(pid, FORCE, chroot, chdir, uid, gid, umask, loader, debug)
 
 
 def stop_command(pid='./run/smtp.pid', KILL=False, ALL=False):

--- a/lamson/utils.py
+++ b/lamson/utils.py
@@ -95,14 +95,15 @@ def check_for_pid(pid, force):
             os.unlink(pid)
 
 
-def start_server(pid, force, chroot, chdir, uid, gid, umask, settings_loader):
+def start_server(pid, force, chroot, chdir, uid, gid, umask, settings_loader, debug):
     """
     Starts the server by doing a daemonize and then dropping priv
     accordingly.  It will only drop to the uid/gid given if both are given.
     """
     check_for_pid(pid, force)
 
-    daemonize(pid, chdir, chroot, umask, files_preserve=[])
+    if not debug:
+        daemonize(pid, chdir, chroot, umask, files_preserve=[])
 
     sys.path.append(os.getcwd())
 

--- a/lamson/utils.py
+++ b/lamson/utils.py
@@ -124,4 +124,4 @@ def start_server(pid, force, chroot, chdir, uid, gid, umask, settings_loader, de
                 time.sleep(100000)
         except KeyboardInterrupt:
             # hard quit, since receiver starts a new thread. dirty but works
-            sys.exit(1)
+            os._exit(1)

--- a/lamson/utils.py
+++ b/lamson/utils.py
@@ -115,3 +115,13 @@ def start_server(pid, force, chroot, chdir, uid, gid, umask, settings_loader, de
         logging.warning("You probably meant to give a uid and gid, but you gave: uid=%r, gid=%r.  Will not change to any user.", uid, gid)
 
     settings.receiver.start()
+
+    if debug:
+        print "Lamson started in debug mode. ctrl-c to quit..."
+        import time
+        try:
+            while True:
+                time.sleep(100000)
+        except KeyboardInterrupt:
+            # hard quit, since receiver starts a new thread. dirty but works
+            sys.exit(1)


### PR DESCRIPTION
also allows ctrl-c to exit, bypassing Python threading <--> keyboard interrupt issue.
