### PR TITLE
queue.Queue logging bug

### DIFF
--- a/lamson/queue.py
+++ b/lamson/queue.py
@@ -145,7 +145,7 @@ class Queue(object):
         try:
             return mail.MailRequest(self.dir, None, None, msg_data)
         except Exception, exc:
-            logging.exception("Failed to decode message: %s" % exc, msg_data)
+            logging.exception("Failed to decode message: %s; msg_data: %r",   exc, msg_data)
             return None
 
 


### PR DESCRIPTION
This fixes queue.Queue.get to actually exceptions from mail.MailRequest(). Without the change, the logging system encounters this error: 

Traceback (most recent call last):
  File "/usr/lib/python2.6/logging/**init**.py", line 768, in emit
    msg = self.format(record)
  File "/usr/lib/python2.6/logging/**init**.py", line 648, in format
    return fmt.format(record)
  File "/usr/lib/python2.6/logging/**init**.py", line 436, in format
    record.message = record.getMessage()
  File "/usr/lib/python2.6/logging/**init**.py", line 306, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting

This error is then swallowed by the logging system and never emitted. This causes there to be no evidence that an unparsable email was even received. 
