### PR TITLE
QueueReceiver should respect the size_limit and oversize_dir arguments

### DIFF
--- a/lamson/server.py
+++ b/lamson/server.py
@@ -226,7 +226,7 @@ class QueueReceiver(object):
                      (self.queue_dir))
         logging.debug("Sleeping for %d seconds..." % self.sleep)
 
-        inq = queue.Queue(self.queue_dir)
+        inq = self.queue
 
         while True:
             keys = inq.keys()


### PR DESCRIPTION
QueueReceiver  init   self.queue  in `__init__`  , but not actually  use it . 
