### PR TITLE
Set correct envelope in sendmail command

### DIFF
--- a/lamson/commands.py
+++ b/lamson/commands.py
@@ -104,8 +104,8 @@ def sendmail_command(port=8825, host='127.0.0.1', debug=0, TRAILING=None):
     relay = server.Relay(host, port=port,
                            debug=debug)
     data = sys.stdin.read()
-    msg = mail.MailRequest(None, TRAILING, None, data)
-    relay.deliver(msg)
+    msg = mail.MailRequest(Peer=None, From=None, To=None, Data=data)
+    relay.deliver(msg, To=TRAILING)
 
 
 


### PR DESCRIPTION
Currently, setting a Bcc recipient when debugging a Lamson app with mutt has no effect, because the envelope isn't specified for the `relay.deliver` call. This commit changes that, so the envelope receiver addresses are the same as the ones mutt (or another sendmail client) has specified on the command line.
