### PR TITLE
Fix errors in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ config = {
      'version': '1.2',
      'scripts': ['bin/lamson'],
      'install_requires': ['chardet', 'jinja2', 'mock', 'nose', 'python-daemon',
-                         python-modargs],
+                         'python-modargs'],
      'packages': ['lamson',
      'lamson.handlers'],
      'name': 'lamson'


### PR DESCRIPTION
I was getting the following error trying to install for development:

```
$ python setup.py install
Traceback (most recent call last):
  File "setup.py", line 19, in <module>
    python-modargs],
NameError: name 'python' is not defined
```

Turns out that "python-modargs" wasn't quoted in setup.py. That's now fixed.
