### PR TITLE
Allow overriding Lamson settings module

### DIFF
--- a/lamson/utils.py
+++ b/lamson/utils.py
@@ -25,9 +25,8 @@ def import_settings(boot_also, from_dir=None, boot_module="config.boot"):
         sys.path.append(from_dir)
 
     # Assumes that the settings.py has the same parent module as boot.py
-    settings_module = "config.settings"
-    if boot_module.endswith(".boot"):
-        settings_module = ".".join( [ boot_module.rsplit(".", 1)[0], "settings" ] )
+    # ie config.boot -> config.settings (just changes the name of the last module)
+    settings_module = ".".join( [ boot_module.rsplit(".", 1)[0], "settings" ] )
 
     settings = __import__(settings_module, globals(), locals()).settings
 

--- a/lamson/utils.py
+++ b/lamson/utils.py
@@ -24,7 +24,12 @@ def import_settings(boot_also, from_dir=None, boot_module="config.boot"):
     if from_dir:
         sys.path.append(from_dir)
 
-    settings = __import__("config.settings", globals(), locals()).settings
+    # Assumes that the settings.py has the same parent module as boot.py
+    settings_module = "config.settings"
+    if boot_module.endswith(".boot"):
+        settings_module = ".".join( [ boot_module.rsplit(".", 1)[0], "settings" ] )
+
+    settings = __import__(settings_module, globals(), locals()).settings
 
     if boot_also:
         __import__(boot_module, globals(), locals())


### PR DESCRIPTION
For simple apps, it would be nice to compact everything 
down into one directory, which sounds fine until you try 
to call it something meaningful (not 'config') - then you
run into problems as the settings loader requires the settings
module to be called 'config.settings'.

This change basically works out where the settings module should be
from the location of the boot module, assuming they have the same 
parent module.
